### PR TITLE
Render valid QR Codes.

### DIFF
--- a/decrypt_otpauth.py
+++ b/decrypt_otpauth.py
@@ -16,6 +16,7 @@ from Crypto.Cipher import AES
 from rncryptor import RNCryptor
 from rncryptor import bord
 
+
 class Type(Enum):
     Unknown = 0
     HOTP = 1
@@ -128,6 +129,7 @@ archiver.update_class_map({'NSMutableString': MutableString})
 archiver.update_class_map({'ACOTPFolder': OTPFolder})
 archiver.update_class_map({'ACOTPAccount': OTPAccount})
 
+
 class RawRNCryptor(RNCryptor):
 
     def post_decrypt_data(self, data):
@@ -135,6 +137,7 @@ class RawRNCryptor(RNCryptor):
            appear over padding for AES (PKCS#7)."""
         data = data[:-bord(data[-1])]
         return data
+
 
 class DangerousUnarchive(archiver.Unarchive):
 
@@ -204,11 +207,12 @@ def decrypt_account(encrypted_otpauth_account):
     else:
         print('Encountered unknow file version', archive['Version'])
         return
-    
+
     render_qr_to_terminal(account.otp_uri(), account.type, account.issuer, account.label)
 
+
 def decrypt_account_11(archive, password):
-	# Get IV and key for actual archive
+    # Get IV and key for actual archive
     iv = hashlib.sha1(archive['IV']).digest()[:16]
     salt = archive['Salt']
     key = hashlib.sha256((salt + '-' + password).encode('utf-8')).digest()
@@ -223,6 +227,7 @@ def decrypt_account_11(archive, password):
     # Construct OTPAccount object from returned dictionary
     return OTPAccount.from_dict(archive)
 
+
 def decrypt_account_12(archive, password):
     # Decrypt using RNCryptor
     data = data = RawRNCryptor().decrypt(archive['Data'], password)
@@ -232,6 +237,7 @@ def decrypt_account_12(archive, password):
 
     # Construct OTPAccount object from returned dictionary
     return OTPAccount.from_dict(archive)
+
 
 @cli.command()
 @click.option('--encrypted-otpauth-backup',
@@ -265,8 +271,9 @@ def decrypt_backup(encrypted_otpauth_backup):
         render_qr_to_terminal(account.otp_uri(), account.type, account.issuer, account.label)
         input("Press Enter to continue...")
 
+
 def decrypt_backup_10(archive, password):
-	# Get IV and key for actual archive
+    # Get IV and key for actual archive
     iv = hashlib.sha1(archive['IV'].encode('utf-8')).digest()[:16]
     salt = archive['Salt']
     key = hashlib.sha256((salt + '-' + password).encode('utf-8')).digest()
@@ -280,6 +287,7 @@ def decrypt_backup_10(archive, password):
 
     return [account for folder in archive['Folders'] for account in folder.accounts]
 
+
 def decrypt_backup_11(archive, password):
     # Decrypt using RNCryptor
     data = data = RawRNCryptor().decrypt(archive['WrappedData'], password)
@@ -288,6 +296,7 @@ def decrypt_backup_11(archive, password):
     archive = DangerousUnarchive(data).top_object()
 
     return [account for folder in archive['Folders'] for account in folder.accounts]
+
 
 if __name__ == '__main__':
     cli()

--- a/decrypt_otpauth.py
+++ b/decrypt_otpauth.py
@@ -205,7 +205,7 @@ def decrypt_account(encrypted_otpauth_account):
     elif archive['Version'] == 1.2:
         account = decrypt_account_12(archive, password)
     else:
-        print('Encountered unknow file version', archive['Version'])
+        click.echo(f'Encountered unknow file version: {archive["Version"]}')
         return
 
     render_qr_to_terminal(account.otp_uri(), account.type, account.issuer, account.label)
@@ -264,7 +264,7 @@ def decrypt_backup(encrypted_otpauth_backup):
     elif archive['Version'] == 1.1:
         accounts = decrypt_backup_11(archive, password)
     else:
-        print('Encountered unknow file version', archive['Version'])
+        click.echo(f'Encountered unknow file version: {archive["Version"]}')
         return
 
     for account in accounts:

--- a/decrypt_otpauth.py
+++ b/decrypt_otpauth.py
@@ -22,6 +22,15 @@ class Type(Enum):
     HOTP = 1
     TOTP = 2
 
+    @property
+    def uri_value(self):
+        if self.value == 0:
+            return 'unknown'
+        if self.value == 1:
+            return 'hotp'
+        if self.value == 2:
+            return 'totp'
+
 
 class Algorithm(Enum):
     Unknown = 0
@@ -110,7 +119,7 @@ class OTPAccount:
         return OTPAccount(label, issuer, secret, type, algorithm, digits, counter, period, refDate)
 
     def otp_uri(self):
-        otp_type = self.type
+        otp_type = self.type.uri_value
         otp_label = quote(f'{self.issuer}:{self.label}')
         otp_parameters = {
             'secret': base64.b32encode(self.secret).decode("utf-8"),

--- a/decrypt_otpauth.py
+++ b/decrypt_otpauth.py
@@ -122,7 +122,7 @@ class OTPAccount:
         otp_type = self.type.uri_value
         otp_label = quote(f'{self.issuer}:{self.label}')
         otp_parameters = {
-            'secret': base64.b32encode(self.secret).decode("utf-8"),
+            'secret': base64.b32encode(self.secret).decode("utf-8").rstrip("="),
             'algorithm': self.algorithm,
             'period': self.period,
             'digits': self.digits,


### PR DESCRIPTION
# QR Code Rendering

The `Enum` based `Type` class was being used to render QR codes, and was not valid.

We'll define a `property` on the `Type` class that provides the valid `totp` or `hotp` string per the spec instead of `Type.TOTP` and `Type.HOTP`.

Example URIs being presented:

Before (**Invalid**): `otpauth://Type.TOTP/...`
After (**Valid**) `otpauth://totp/...`

# Secret Padding

Remove padding on the Base32 encoded secret per [the specifications](https://github.com/google/google-authenticator/wiki/Key-Uri-Format#secret)

# Style Fixes
Also included some style fixes:
  - remove tabs, replace with 4 space indent
  - remove some stray blank lines with spaces in them
  - adhere to style of two blank lines around class and function declarations
  - use `click.echo` instead of `print`