### PR TITLE
Bump to Python 3.10 and replace bpylist

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 
 [packages]
 rncryptor = "==3.2.0"
-bpylist = "==0.1.4"
+bpylist2 = "==4.0.1"
 click = "==6.7"
 pyqrcode = "==1.2.1"
 pycryptodome = "==3.9.1"

--- a/Pipfile
+++ b/Pipfile
@@ -13,4 +13,4 @@ pyqrcode = "==1.2.1"
 pycryptodome = "==3.9.1"
 
 [requires]
-python_version = "3.7"
+python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3a9aa3cf92e33eb33f1ae837e0b466ec0827564e1abc6766112371ee29d937c3"
+            "sha256": "859720381b640afb70a49d3416240a0ce85703e2b95fddf246f3d7b995870af7"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.10"
         },
         "sources": [
             {
@@ -16,12 +16,13 @@
         ]
     },
     "default": {
-        "bpylist": {
+        "bpylist2": {
             "hashes": [
-                "sha256:ac065c9f7b804a201999ebbc31b02df18e0fc29e03bcb1eac3e63696599b88ce"
+                "sha256:92a4fe810f919777e22623d6c90c4ee70cc8cbd156bc8297313221c85bc2f2da",
+                "sha256:ae36e14f856100a1a2a60ecdbf703fab949932cea6a1ba562299452983906969"
             ],
             "index": "pypi",
-            "version": "==0.1.4"
+            "version": "==4.0.1"
         },
         "click": {
             "hashes": [
@@ -30,6 +31,12 @@
             ],
             "index": "pypi",
             "version": "==6.7"
+        },
+        "pycrypto": {
+            "hashes": [
+                "sha256:f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c"
+            ],
+            "version": "==2.6.1"
         },
         "pycryptodome": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ If you find problems with the file format (in particular security related issues
 
 ## Requirements
 
-  - [Python 3.7](https://www.python.org/downloads/)
+  - [Python 3.10](https://www.python.org/downloads/)
   - [pipenv](https://github.com/pypa/pipenv)
   - An encrypted OTP Auth backup/account file
 

--- a/decrypt_otpauth.py
+++ b/decrypt_otpauth.py
@@ -8,8 +8,8 @@ from urllib.parse import quote
 
 import pyqrcode
 
-from bpylist import archiver
-from bpylist.archive_types import uid
+from bpylist2 import archiver
+from plistlib import UID
 
 from Crypto.Cipher import AES
 
@@ -179,7 +179,7 @@ class DangerousUnarchive(archiver.Unarchive):
             return raw_obj
 
         class_uid = raw_obj.get('$class')
-        if not isinstance(class_uid, uid):
+        if not isinstance(class_uid, UID):
             raise archiver.MissingClassUID(raw_obj)
 
         klass = self.class_for_uid(class_uid)


### PR DESCRIPTION
Given the latest Ubuntu LTS (22.04) ships with Python 3.10, made a few changes to bump the Python version. `bpylist` isn't maintained and does not compile in the latest versions of Python, so that has been replaced.